### PR TITLE
Port runhttp.py to Python3

### DIFF
--- a/runhttp.py
+++ b/runhttp.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-from SimpleHTTPServer import SimpleHTTPRequestHandler
-import BaseHTTPServer
+from http.server import SimpleHTTPRequestHandler
+import http.server
 
 class CORSRequestHandler (SimpleHTTPRequestHandler):
     def end_headers (self):
@@ -8,4 +8,5 @@ class CORSRequestHandler (SimpleHTTPRequestHandler):
         SimpleHTTPRequestHandler.end_headers(self)
 
 if __name__ == '__main__':
-    BaseHTTPServer.test(CORSRequestHandler, BaseHTTPServer.HTTPServer)
+    http.server.test(CORSRequestHandler, http.server.HTTPServer)
+


### PR DESCRIPTION
used `2to3` for porting the program that starts the server to Python 3. Site seems to be functional.